### PR TITLE
Fix kubernetes provider

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -16,7 +16,7 @@ RUN python setup.py install
 
 VOLUME /answers.conf
 
-LABEL RUN docker run -it --privileged -v ${DATADIR}:/atomicapp -v /run:/run -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
+LABEL RUN docker run -it --rm --privileged -v ${DATADIR}:/atomicapp -v /run:/run -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
 LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${DATADIR}:/atomicapp -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE containerapp -v install --update --path /atomicapp /application-entity
 
 CMD containerapp -a /answers.conf

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -14,10 +14,11 @@ WORKDIR /opt/atomicapp
 
 RUN python setup.py install
 
-VOLUME /answers.conf
+WORKDIR /application-entity
+VOLUME /application-entity/answers.conf
 
-LABEL RUN docker run -it --rm --privileged -v ${DATADIR}:/atomicapp -v /run:/run -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
-LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${DATADIR}:/atomicapp -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE containerapp -v install --update --path /atomicapp /application-entity
+LABEL RUN docker run -it --rm --privileged -v ${PWD}:/atomicapp -v /run:/run -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
+LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE containerapp -v install --path /atomicapp /application-entity
 
-CMD containerapp -a /answers.conf
+CMD  containerapp -h
 

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -16,7 +16,7 @@ RUN python setup.py install
 WORKDIR /application-entity
 VOLUME /application-entity/answers.conf
 
-LABEL RUN docker run -it --privileged -v ${PWD}:/atomicapp -v /run:/run -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
+LABEL RUN docker run -it --rm --privileged -v ${PWD}:/atomicapp -v /run:/run -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
 LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE containerapp -v install --path /atomicapp /application-entity
 
 CMD  containerapp -h

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -21,10 +21,11 @@ WORKDIR /opt/atomicapp
 
 RUN python setup.py install
 
-VOLUME /answers.conf
+WORKDIR /application-entity
+VOLUME /application-entity/answers.conf
 
-LABEL RUN docker run -it --rm --privileged -v ${DATADIR}:/atomicapp -v /run:/run -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
-LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${DATADIR}:/atomicapp -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE containerapp -v install --update --path /atomicapp /application-entity
+LABEL RUN docker run -it --rm --privileged -v ${PWD}:/atomicapp -v /run:/run -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
+LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE containerapp -v install --path /atomicapp /application-entity
 
-CMD containerapp -a /answers.conf
+CMD  containerapp -h
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -23,7 +23,7 @@ RUN python setup.py install
 
 VOLUME /answers.conf
 
-LABEL RUN docker run -it --privileged -v ${DATADIR}:/atomicapp -v /run:/run -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
+LABEL RUN docker run -it --rm --privileged -v ${DATADIR}:/atomicapp -v /run:/run -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE containerapp -v run /atomicapp
 LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${DATADIR}:/atomicapp -v /:/host -v ${CONFDIR}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE containerapp -v install --update --path /atomicapp /application-entity
 
 CMD containerapp -a /answers.conf

--- a/containerapp/providers/kubernetes.py
+++ b/containerapp/providers/kubernetes.py
@@ -18,7 +18,7 @@ class KubernetesProvider(Provider):
         self.dryrun = dryrun
 
     def _callK8s(self, path):
-        cmd = ["kubectl", "create", "-f", path, "--api-version=v1beta1"]
+        cmd = ["kubectl", "create", "-f", path]
         print("Calling: %s" % " ".join(cmd))
 
         if self.dryrun:

--- a/containerapp/providers/kubernetes.py
+++ b/containerapp/providers/kubernetes.py
@@ -10,9 +10,10 @@ class KubernetesProvider(Provider):
     component_dir = None
     debug = None
     dryrun = None
-    def init(self, config, component_dir, debug, dryrun):
+    def init(self, config, component_dir, dst_dir, debug, dryrun):
         self.confif = config
         self.component_dir = component_dir
+        self.dst_dir = dst_dir
         self.debug = debug
         self.dryrun = dryrun
 
@@ -30,9 +31,9 @@ class KubernetesProvider(Provider):
 
     def deploy(self):
         kube_order = OrderedDict([("service", None), ("rc", None), ("pod", None)]) #FIXME
-        for artifact in os.listdir(self.component_dir):
+        for artifact in self.component_dir:
             data = None
-            with open(os.path.join(self.component_dir, artifact), "r") as fp:
+            with open(os.path.join(self.dst_dir, artifact), "r") as fp:
                 data = json.load(fp)
             if "kind" in data:
                 kube_order[data["kind"].lower()] = artifact
@@ -43,5 +44,5 @@ class KubernetesProvider(Provider):
             if not kube_order[artifact]:
                 continue
         
-            k8s_file = os.path.join(self.component_dir, kube_order[artifact])
+            k8s_file = os.path.join(self.dst_dir, kube_order[artifact])
             self._callK8s(k8s_file)

--- a/containerapp/run.py
+++ b/containerapp/run.py
@@ -124,7 +124,7 @@ class Run():
             logger.info("Using provider %s for component %s" % (self.params.provider, component))
         else:
             raise Exception("Something is broken - couldn't get the provider")
-        provider.init(self.params.getValues(component), artifact_provider_list, dst_dir, self.dryrun, logger)
+        provider.init(self.params.getValues(component), artifact_provider_list, dst_dir, self.debug, self.dryrun)
         provider.deploy()
 
     def run(self):


### PR DESCRIPTION
These changes enable kubernetes apps to be deployed when run from a host with the kubectl client. I tested both the fedora and centos Dockerfiles.

One caveat is that the kubernetes bindmounts will cause failures if kubectl is not install on the host. We are mounting `-v /:/host`--a bit overkill--so we could add some logic in the code to check if the target provider is installed.